### PR TITLE
Add palette option to Seedbot

### DIFF
--- a/custom_sprites_portraits.py
+++ b/custom_sprites_portraits.py
@@ -170,3 +170,8 @@ def paint():
         f_sprites.append(str(x[1]['s_id']))
     return f" -name {'.'.join(f_names[:14])} -cpor {'.'.join(f_portraits[:14])}.{f_portraits[15]} -cspr" \
            f" {'.'.join(f_sprites)} -cpal {'.'.join(f_palettes)} -cspp {'.'.join(f_spalettes)}"
+
+def palette():
+    f_palettes = [str(x) for x in random.sample(list(id_palette.keys()), 7)]
+    f_spalettes = [str(x) for x in random.choices(list(range(0, 6)), k=20)]
+    return f" -cpal {'.'.join(f_palettes)} -cspp {'.'.join(f_spalettes)}"

--- a/db/presethelp.txt
+++ b/db/presethelp.txt
@@ -21,6 +21,7 @@
 **&all_pally** - replaces all enemy drops/steals with Paladin Shields... for science?
 **&steve** - everything is and always will be STEVE
 **&paint** - randomize the sprites, portraits and palettes
+**&palette** - randomize the palettes, keep the vanilla sprites & portraits
 **&kupo** - moogles day out!
 **&dev** - rolls your seed using a dev version of the randomizer (useful for appending to presets - use **!devhelp** for more info)
 **&tunes** - randomizes the music with music from other games

--- a/db/seedhelp.txt
+++ b/db/seedhelp.txt
@@ -20,6 +20,7 @@
 **&all_pally** - replaces all enemy drops/steals with Paladin Shields... for science?
 **&steve** - everything is and always will be STEVE
 **&paint** - randomize the sprites, portraits and palettes
+**&palette** - randomize the palettes, keep the vanilla sprites & portraits
 **&kupo** - moogles day out!
 **&dev** - rolls your seed using a dev version of the randomizer (useful for appending to presets - use **!devhelp** for more info)
 **&tunes** - randomizes the music with music from other games

--- a/parse_commands.py
+++ b/parse_commands.py
@@ -234,12 +234,12 @@ async def parse_bot_command(message):
         if x.strip() == "nospoiler":
             flagstring = flagstring.replace(" -sl", "")
             mtype += "_nospoiler"
-        if x.strip() == "palette":
-            flagstring += custom_sprites_portraits.palette()
-            mtype += "_palette"
         if x.strip() == "noflashes":
             flagstring = ''.join([flagstring.replace(" -frm", "").replace(" -frw", ""), " -frw"])
             mtype += "_noflashes"
+        if x.strip() == "palette":
+            flagstring += custom_sprites_portraits.palette()
+            mtype += "_palette"
 
     if message.content.startswith("!gitgud"):
         with open('db/user_presets.json') as checkfile:

--- a/parse_commands.py
+++ b/parse_commands.py
@@ -270,6 +270,9 @@ async def parse_bot_command(message):
         if x.strip() == "nospoiler":
             flagstring = flagstring.replace(" -sl", "")
             mtype += "_nospoiler"
+        if x.strip() == "palette":
+            flagstring += custom_sprites_portraits.palette()
+            mtype += "_palette"
 
     # Next, let's figure out if this seed will be rolled locally or on the website
     if dev:


### PR DESCRIPTION
Add new palette command to parse_commands and new routine to custom_sprites_portraits. This will randomize the color palettes but keep the vanilla sprites & portraits. Update help.