### PR TITLE
add &cg option to force the Character Gated mode for rando/chaos commands

### DIFF
--- a/db/presethelp.txt
+++ b/db/presethelp.txt
@@ -34,3 +34,4 @@
 **&local** - rolls the seed on SeedBot's local instance of WC instead of on the website
 **&ap** - generates an Archipelago YAML of flagset instead of rolling a seed - alternatively, you can use **&apts** to turn on the `treasuresanity` option when creating the YAML
 **&flagsonly** - prints the flagset for your seed instead of rolling it
+**&cg** - forces the Character Gated mode/flag

--- a/db/seedhelp.txt
+++ b/db/seedhelp.txt
@@ -34,6 +34,7 @@
 **&local** - rolls the seed on SeedBot's local instance of WC instead of on the website
 **&ap** - generates an Archipelago YAML of flagset instead of rolling a seed - alternatively, you can use **&apts** to turn on the `treasuresanity` option when creating the YAML
 **&flagsonly** - prints the flagset for your seed instead of rolling it
+**&cg** - forces the Character Gated mode/flag
 
 --------------------------------------------
 **Other Commands**

--- a/functions.py
+++ b/functions.py
@@ -432,6 +432,10 @@ async def argparse(ctx, flags, args=None, mtype=""):
                 )
                 mtype += "_yeet"
 
+            if x.strip() in ("cg", "CG"):
+                flagstring = flagstring.replace(" -open ", " -cg ")
+                mtype += "_cg"
+
             if x.strip().casefold() == "palette":
                 flagstring += custom_sprites_portraits.palette()
                 mtype += "_palette"


### PR DESCRIPTION
There's a non-zero chance that the !rando or !chaos or !truechaos gives you an open world seed, and this option will help ensure that Seedbot will always use the character gated mode with those other commands.