### PR TITLE
add &emptychests argument to force -cce flag

### DIFF
--- a/db/presethelp.txt
+++ b/db/presethelp.txt
@@ -16,6 +16,7 @@
 
 **&loot** - Randomize the drops and steals of enemies
 **&emptyshops** - All shops are empty!
+**&emptychests** - All chests are empty!
 **&steve** - everything is and always will be STEVE - you can add your own word after `&steve` to customize your fun!
 **&paint** - randomize the sprites, portraits and palettes
 **&palette** - randomize the palettes, keep the vanilla sprites & portraits

--- a/db/seedhelp.txt
+++ b/db/seedhelp.txt
@@ -16,6 +16,7 @@
 
 **&loot** - Randomize the drops and steals of enemies
 **&emptyshops** - All shops are empty!
+**&emptychests** - All chests are empty!
 **&steve** - everything is and always will be STEVE - you can add your own word after `&steve` to customize your fun!
 **&paint** - randomize the sprites, portraits and palettes
 **&palette** - randomize the palettes, keep the vanilla sprites & portraits

--- a/functions.py
+++ b/functions.py
@@ -414,6 +414,17 @@ async def argparse(ctx, flags, args=None, mtype=""):
                     flagstring = "-".join(splitflags)
                 mtype += ' -emptyshops'
 
+            # if &emptychests was specified
+            if x.strip() in ("emptychests", "EmptyChests"):
+                splitflags = [flag for flag in flagstring.split("-")] # Create list of flags
+                for flag in splitflags:
+                    # if one of the chest flags are found (-ccsr, -ccrt, -ccrs)
+                    if flag.split(" ")[0] in ("ccsr", "ccrt", "ccrs"):
+                        #  override with Empty (-cce)
+                        splitflags[splitflags.index(flag)] = 'cce '
+                    flagstring = "-".join(splitflags)
+                mtype += ' -emptychests'
+
             if x.strip().casefold() == "yeet":
                 flagstring = "".join(
                     [


### PR DESCRIPTION
Override any chest argument flag with the -cce flag to force empty chests.