### PR TITLE
Added '&zozo' argument to shuffle characters 

### DIFF
--- a/components/views.py
+++ b/components/views.py
@@ -149,6 +149,11 @@ class ReRollExtraView(View):
                 description="Hides the flags from the log and track menu",
             ),
             discord.SelectOption(
+                label="Zozo",
+                emoji="<:lul:840298070439624774>",
+                description="Shuffles characters and hides their original names",
+            ),
+            discord.SelectOption(
                 label="STEVE",
                 emoji="<:Kappa:698619218358304868>",
                 description="Everything is and always will be STEVE",

--- a/functions.py
+++ b/functions.py
@@ -261,6 +261,43 @@ async def preset_argparse(args=None):
     else:
         return None
 
+# Function to parse the flagstring and extract custom lists
+def parse_flagstring(flagstring, key, default_list, convert_func=None):
+    if f"-{key}" in flagstring:
+        start = flagstring.find(f"-{key}") + len(f"-{key} ")
+        end = flagstring.find(" ", start)
+        if end == -1:  # If it's the last flag in the string
+            end = len(flagstring)
+        custom_list = flagstring[start:end].split('.')
+        return [convert_func(item) if convert_func else item for item in custom_list]
+    return default_list
+
+
+# Function to shuffle while ensuring no element remains in its original position
+def shuffle_list(ordered_list):
+    """
+    Shuffle a list while ensuring no element remains in its original position.
+    """
+    shuffled = ordered_list[:]
+    while True:
+        random.shuffle(shuffled)
+        if all(shuffled[i] != ordered_list[i] for i in range(len(ordered_list))):
+            return shuffled
+
+
+# Function to update name/cpor/cspr/cspp flag's argument with a zozo shuffled version of the flag's argument
+def zozoify_flag (flagstring, key, shuffled_list):
+    if f"-{key}" not in flagstring:
+        # Add the key and shuffled list to the flagstring
+        flagstring += f" -{key} {'.'.join(map(str, shuffled_list))}"
+    else:
+        # Replace the existing key's list with the shuffled list
+        start = flagstring.find(f"-{key}") + len(f"-{key} ")
+        end = flagstring.find(" ", start)
+        if end == -1:  # If it's the last flag
+            end = len(flagstring)
+        flagstring = flagstring[:start] + '.'.join(map(str, shuffled_list)) + flagstring[end:]
+    return flagstring
 
 async def argparse(ctx, flags, args=None, mtype=""):
     """Parses all arguments and returns:
@@ -282,7 +319,8 @@ async def argparse(ctx, flags, args=None, mtype=""):
         "doors_lite",
         "Doors Lite",
         "local",
-        "lg1"
+        "lg1",
+        "zozo"
     ]
     badflags = [
         "stesp"
@@ -315,14 +353,14 @@ async def argparse(ctx, flags, args=None, mtype=""):
             if x.strip().casefold() in map(str.lower, local_args):
                 islocal = True
                 break
-        
+
         for x in args:
             if x.strip().casefold() == "practice":
                 islocal = True
                 dev = "practice"
                 if mtype != "practice":
                     mtype += "_practice"
-                    flagstring += " -kprac"    
+                    flagstring += " -kprac"
 
             if x.strip().casefold() == "dev":
                 dev = "dev"
@@ -509,7 +547,7 @@ async def argparse(ctx, flags, args=None, mtype=""):
                 with open("db/template.yaml") as yaml:
                     yaml_content = yaml.read()
                 splitflags = [flag for flag in flagstring.split("-") if flag.split(" ")[0] not in badflags] # Create list of flags excluding all bad flags
-                for flag in splitflags: 
+                for flag in splitflags:
                     if flag.split(" ")[0] == "name": # Remove any spaces from names since it breaks AP generation
                         splitflags[splitflags.index(flag)] = f'name {"".join(flag.split(" ")[1:]).replace(" ","")} '
                     if flag.split(" ")[0] == "open":
@@ -559,9 +597,43 @@ async def argparse(ctx, flags, args=None, mtype=""):
                     steve_args = "STEVE "
                 islocal = True
 
+            if x.strip() in ("zozo", "Zozo"):
+                default_character_names = ["TERRA", "LOCKE", "CYAN", "SHADOW", "EDGAR", "SABIN",
+                                           "CELES", "STRAGO", "RELM", "SETZER", "MOG", "GAU",
+                                           "GOGO", "UMARO"]
+                default_portraits = list(range(len(default_character_names)+1))
+                default_sprites = list(range(len(default_character_names)))+[14,15,18,19,20,21]
+                default_palettes = [2, 1, 4, 4, 0, 0, 0, 3, 3, 4, 5, 3, 3, 5, 1, 0, 6,
+                                    1, 0, 3]
+
+                character_names = parse_flagstring(flagstring, "name", default_character_names)
+                portraits = parse_flagstring(flagstring, "cpor", default_portraits, int)
+                sprites = parse_flagstring(flagstring, "cspr", default_sprites, int)
+                palettes = parse_flagstring(flagstring, "cspp", default_palettes, int)
+
+                # Shuffle indices based on the character names length
+                shuffled_indices = shuffle_list(list(range(len(character_names))))
+
+                # Apply consistent shuffle to all lists
+                shuffled_characters = [character_names[i] for i in shuffled_indices]
+
+                # Apply the same shuffle indices to the first 14 items of sprites, portraits, and palettes
+                shuffled_portraits = [portraits[i] for i in shuffled_indices[:14]] + portraits[14:]
+                shuffled_sprites = [sprites[i] for i in shuffled_indices[:14]] + sprites[14:]
+                shuffled_palettes = [palettes[i] for i in shuffled_indices[:14]] + palettes[14:]
+
+                # Update flagstring
+                flagstring = zozoify_flag(flagstring, "name", shuffled_characters)
+                flagstring = zozoify_flag(flagstring, "cpor", shuffled_portraits)
+                flagstring = zozoify_flag(flagstring, "cspr", shuffled_sprites)
+                flagstring = zozoify_flag(flagstring, "cspp", shuffled_palettes)
+                flagstring = flagstring.replace(" -ond ", " ") # remove original name display
+
+                mtype += "_zozo"
+
             if x.startswith("desc"):
                 seed_desc = " ".join(x.split()[1:])
-            
+
             # if lg1 option
             if x.strip() == "lg1":
                 if dev == "dev":


### PR DESCRIPTION
&zozo shuffles characters in the style of the Battlegrounds: Zozo flagset. Specifically it:
- takes the list of starting characters and shuffles it, ensuring that no character is in its original location
- reorders the first 14 elements in the -name, -cpor, -cspr, and -cspp flags; if these flags are not present in the original flagset, it populates them with the default values and then shuffles the appropriate elements
- removes the Original Name Display (-ond) flag, if present in the original flagstring

This means that a flagset with custom names/sprites/palettes should still be Zozo-shuffled accurately.

Zozo is also added to the "Reroll with Extras" view:
![image](https://github.com/user-attachments/assets/8a24c5bd-8be9-4019-8445-ef8cc9bfdbde)
