### PR TITLE
Add Shuffle by World Parameter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,4 +22,7 @@
 	path = WorldsCollide_location_gating1
 	url = https://github.com/BriGuy7727/WorldsCollide.git
 	branch = loc-gated
-
+[submodule "WorldsCollide_shuffle_by_world"]
+	path = WorldsCollide_shuffle_by_world
+	url = https://github.com/JackQuincy/WorldsCollide.git
+	branch = chest-shop-suffle-by-world

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,4 +25,4 @@
 [submodule "WorldsCollide_shuffle_by_world"]
 	path = WorldsCollide_shuffle_by_world
 	url = https://github.com/JackQuincy/WorldsCollide.git
-	branch = chest-shop-suffle-by-world
+	branch = worlds-divided

--- a/cogs/funcs.py
+++ b/cogs/funcs.py
@@ -167,6 +167,22 @@ class funcs(commands.Cog):
             return await ctx.send(f"Something went wrong:\n{e}")
 
     @commands.hybrid_command(
+        name="worldshufflepull", description="Update the FF6WC Shuffle by World submodule"
+    )
+    async def worldshufflepull(self, ctx):
+        user = await functions.get_user(ctx.author.id)
+        try:
+            if user and user[2] == 1:
+                g = git.cmd.Git("WorldsCollide_shuffle_by_world/")
+                g.switch("chest-shop-suffle-by-world")
+                output = g.pull()
+                return await ctx.send(f"Git message: {output}")
+            else:
+                return await ctx.send("Sorry, only Git Users can use this command!", ephemeral=True)
+        except git.exc.GitError as e:
+            return await ctx.send(f"Something went wrong:\n{e}")
+
+    @commands.hybrid_command(
         name="version", description="Get version information for Worlds Collide"
     )
     async def version(self, ctx):

--- a/functions.py
+++ b/functions.py
@@ -323,7 +323,8 @@ async def argparse(ctx, flags, args=None, mtype=""):
         "doorx",
         "local",
         "lg1",
-        "lg2"
+        "lg2",
+        "ws"
     ]
     badflags = [
         "stesp"
@@ -694,6 +695,18 @@ async def argparse(ctx, flags, args=None, mtype=""):
                     )
                     dev = "lg2"
                     mtype += "_lg2"
+
+            # if ws option
+            if x.strip() == "ws":
+                if dev == "dev":
+                    return await ctx.channel.send(
+                        "Sorry, shuffle by world doesn't work on dev currently"
+                    )
+                else:
+                    flagstring = flagstring.replace("-ccsr ", "-ccswr ")
+                    flagstring = flagstring.replace("-sisr ", "-siswr ")
+                    dev = "ws"
+                    mtype += "_ws"
 
         if islocal:
             try:

--- a/run_local.py
+++ b/run_local.py
@@ -19,6 +19,8 @@ async def local_wc(flags, beta, filename):
         rolldir = 'WorldsCollide_Door_Rando/'
     elif beta == "lg1" or beta == "lg2":
         rolldir = 'WorldsCollide_location_gating1/'
+    elif beta == "ws":
+        rolldir = "WorldsCollide_shuffle_by_world/"
     else:
         rolldir = "WorldsCollide/"
     try:


### PR DESCRIPTION
Adding support for `&ws` powered by changes in the Worlds Collide fork https://github.com/JackQuincy/WorldsCollide/tree/chest-shop-suffle-by-world .  This changes shuffle and random settings for chests and shops to a version that only shuffles stuff within a single world (WoB vs WoR).

Open to suggestions on how to name the flag etc.
I wasn't able to test locally due to my environment not having a `discord ` module. So please make sure I did the little things right.  I'm not much of a python dev.