### PR TITLE
Make the shuffle by world git update use the correct branch

### DIFF
--- a/cogs/funcs.py
+++ b/cogs/funcs.py
@@ -174,7 +174,7 @@ class funcs(commands.Cog):
         try:
             if user and user[2] == 1:
                 g = git.cmd.Git("WorldsCollide_shuffle_by_world/")
-                g.switch("chest-shop-suffle-by-world")
+                g.switch("worlds-divided")
                 output = g.pull()
                 return await ctx.send(f"Git message: {output}")
             else:


### PR DESCRIPTION
Switching to the correct branch when running the command to update the bot to the latest version of my fork.