### PR TITLE
Adding flag for enabling custom items worlds collide flag

### DIFF
--- a/db/presethelp.txt
+++ b/db/presethelp.txt
@@ -38,3 +38,5 @@
 **&cg** - forces the Character Gated mode/flag
 **&lg1** - forces the Location Gating 1 mode/flag
 **&lg2** - forces the Location Gating 2 mode/flag
+**&ws** - forces shuffling shops and chests by world
+**&csi** - allows adding a -si flag for creating custom starting item kits

--- a/db/seedhelp.txt
+++ b/db/seedhelp.txt
@@ -38,6 +38,8 @@
 **&cg** - forces the Character Gated mode/flag
 **&lg1** - forces the Location Gating 1 mode/flag
 **&lg2** - forces the Location Gating 2 mode/flag
+**&ws** - forces shuffling shops and chests by world
+**&csi** - allows adding a -si flag for creating custom starting item kits
 
 --------------------------------------------
 **Other Commands**

--- a/functions.py
+++ b/functions.py
@@ -324,7 +324,8 @@ async def argparse(ctx, flags, args=None, mtype=""):
         "local",
         "lg1",
         "lg2",
-        "ws"
+        "ws",
+        "csi"
     ]
     badflags = [
         "stesp"
@@ -707,6 +708,17 @@ async def argparse(ctx, flags, args=None, mtype=""):
                     flagstring = flagstring.replace("-sisr ", "-siswr ")
                     dev = "ws"
                     mtype += "_ws"
+
+            # if csi option
+            if x.strip() == "csi":
+                if dev == "dev":
+                    return await ctx.channel.send(
+                        "Sorry, custom starting items doesn't work on dev currently"
+                    )
+                else:
+                    # this option is to enable a flag that will need to be set else where
+                    dev = "csi"
+                    mtype += "_csi"
 
         if islocal:
             try:

--- a/run_local.py
+++ b/run_local.py
@@ -19,7 +19,7 @@ async def local_wc(flags, beta, filename):
         rolldir = 'WorldsCollide_Door_Rando/'
     elif beta == "lg1" or beta == "lg2":
         rolldir = 'WorldsCollide_location_gating1/'
-    elif beta == "ws":
+    elif beta == "ws" or beta == "csi":
         rolldir = "WorldsCollide_shuffle_by_world/"
     else:
         rolldir = "WorldsCollide/"


### PR DESCRIPTION
I added a new flag for creating custom starter kits.  This is just changes to enable that without forcing shops shuffled by world.