### PR TITLE
update &cg to remove whitespace that can mess up flag parsing

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -483,7 +483,7 @@ async def argparse(ctx, flags, args=None, mtype=""):
                 mtype += "_yeet"
 
             if x.strip() in ("cg", "CG"):
-                flagstring = flagstring.replace("-open", "-cg")
+                flagstring = flagstring.replace(' -open ', ' -cg ').replace('-open', '-cg')
                 mtype += "_cg"
 
             if x.strip().casefold() == "palette":

--- a/functions.py
+++ b/functions.py
@@ -483,7 +483,7 @@ async def argparse(ctx, flags, args=None, mtype=""):
                 mtype += "_yeet"
 
             if x.strip() in ("cg", "CG"):
-                flagstring = flagstring.replace(" -open ", " -cg ")
+                flagstring = flagstring.replace("-open", "-cg")
                 mtype += "_cg"
 
             if x.strip().casefold() == "palette":


### PR DESCRIPTION
Since -open or -cg is usually the first string passed, there often is not whitespace to the left of this flag. This change will ensure that the flag is detected & replaced properly by the argparse function.