### PR TITLE
feat: Add 'Make .yaml' button to preset cards

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -56,6 +56,11 @@ button,
   --pico-border-color: #c62828;
   --pico-color: #ffffff;
 }
+.btn-gray {
+  --pico-background-color: #6c757d;
+  --pico-border-color: #6c757d;
+  --pico-color: #ffffff;
+}
 
 /* --- Other Styles --- */
 article dl dt {

--- a/templates/webapp/_preset_card.html
+++ b/templates/webapp/_preset_card.html
@@ -63,6 +63,8 @@
         >
         {% if preset.validation_status == 'VALID' %}Roll Seed{% else %}Invalid{% endif %}</button>
 
+        <a href="{% url 'make-yaml' preset.pk %}" role="button" class="btn-gray">📄 Make .yaml</a>
+
         {% if preset.creator_id == user_discord_id %}
             <a href="{% url 'preset-update' preset.pk %}" role="button" class="btn-orange">Edit</a>
         {% endif %}

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('<path:pk>/toggle-feature/', views.toggle_feature_view, name='toggle-feature'),
     path('<path:pk>/toggle-favorite/', views.toggle_favorite_view, name='toggle-favorite'),
     path('<path:pk>/roll/', views.roll_seed_dispatcher_view, name='roll-seed'),
+    path('<path:pk>/make-yaml/', views.make_yaml_view, name='make-yaml'),
     path('<path:pk>/', views.preset_detail_view, name='preset-detail'),
     path('preset-status/<path:pk>/', views.preset_status_view, name='preset-status'),
 ]

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.shortcuts import render, get_object_or_404, redirect
 from django.core.exceptions import PermissionDenied
 from django.db.models import Q, Count
-from django.http import JsonResponse, Http404
+from django.http import JsonResponse, Http404, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from allauth.socialaccount.models import SocialAccount
@@ -308,6 +308,24 @@ def toggle_favorite_view(request, pk):
             return JsonResponse({'status': 'success', 'favorited': False})
     except Exception as e:
         return JsonResponse({'status': 'error', 'message': str(e)}, status=500)
+
+def make_yaml_view(request, pk):
+    preset = get_object_or_404(Preset, pk=pk)
+
+    with open(os.path.join(settings.BASE_DIR, 'data', 'template.yaml'), 'r') as f:
+        template_content = f.read()
+
+    # Replace placeholders
+    yaml_content = template_content.replace('flags', preset.flags)
+    yaml_content = yaml_content.replace('ts_option', 'on_with_additional_gating')
+
+    # Generate a filename
+    filename = f"{preset.preset_name.replace(' ', '_')}.yaml"
+
+    response = HttpResponse(yaml_content, content_type='application/x-yaml')
+    response['Content-Disposition'] = f'attachment; filename="{filename}"'
+
+    return response
 
 def roll_seed_dispatcher_view(request, pk):
     try:


### PR DESCRIPTION
This commit introduces a new feature that allows users to download an AP YAML file for any preset directly from the preset card. A 'Make .yaml' button has been added to the preset cards on the 'all presets', 'my profile', and 'preset detail' views. When clicked, this button generates and serves a YAML file based on the preset's flags, with the `treasuresanity` option set to `on_with_additional_gating`.