### PR TITLE
Fix: Remove async_to_sync from flag_builder calls

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -414,11 +414,11 @@ def roll_seed_dispatcher_view(request, pk):
 
         # For "Quick Roll" presets, generate flags on the fly, ignoring stored flags.
         if preset.preset_name == "Quick Roll - Rando":
-            preset.flags = async_to_sync(flag_builder.standard)()
+            preset.flags = flag_builder.standard()
         elif preset.preset_name == "Quick Roll - Chaos":
-            preset.flags = async_to_sync(flag_builder.chaos)()
+            preset.flags = flag_builder.chaos()
         elif preset.preset_name == "Quick Roll - True Chaos":
-            preset.flags = async_to_sync(flag_builder.true_chaos)()
+            preset.flags = flag_builder.true_chaos()
 
         args_list = preset.arguments.split() if preset.arguments else []
         


### PR DESCRIPTION
The functions in `flag_builder.py` were recently changed from async to regular functions. This change updates the calls to these functions in `webapp/views.py` to remove the `async_to_sync` wrapper, which was causing an error on the quick roll page.