### PR TITLE
feat: require client-side ROM validation prior to seed generation

### DIFF
--- a/patch_base.html.diff
+++ b/patch_base.html.diff
@@ -1,0 +1,37 @@
+--- templates/base.html	2023-10-25 15:00:00.000000000 -0400
++++ templates/base.html	2023-10-25 15:01:00.000000000 -0400
+@@ -145,6 +145,34 @@
+         </article>
+     </dialog>
+
++    <dialog id="rom-validation-modal">
++        <article>
++            <header>
++                <button aria-label="Close" rel="prev" onclick="closeModal('rom-validation-modal')"></button>
++                <h3>Validate ROM File</h3>
++            </header>
++            <div id="rom-validation-content">
++                <p>
++                    To download patched ROM files, please validate that you own a copy of Final Fantasy III.
++                    <br><br>
++                    <em>"Obtain a Final Fantasy III Version 1.0 US ROM. Worlds Collide will automatically validate the uploaded ROM file and return an error if it does not match the expected sha256 value. Headered and unheadered ROMs are both acceptable."</em>
++                </p>
++                <input type="file" id="rom-validation-file" accept=".smc,.sfc">
++                <div id="rom-validation-error" style="color: var(--pico-form-element-invalid-border-color); display: none; margin-top: 1rem;">
++                    Invalid ROM file. The sha256 value does not match the expected value.
++                </div>
++                <label for="remember-rom-validation" style="margin-top: 1rem;">
++                    <input type="checkbox" id="remember-rom-validation" name="remember-rom-validation" checked>
++                    Remember this validation for future visits
++                </label>
++            </div>
++            <footer class="button-group">
++                <button type="button" class="secondary" onclick="closeModal('rom-validation-modal')">Cancel</button>
++                <button type="button" id="rom-validation-submit">Validate and Roll</button>
++            </footer>
++        </article>
++    </dialog>
++
+     <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
+     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+     <script src="{% static 'js/pico.min.js' %}"></script>

--- a/patch_base_js.diff
+++ b/patch_base_js.diff
@@ -1,0 +1,88 @@
+--- templates/base.html	2023-10-25 15:01:00.000000000 -0400
++++ templates/base.html	2023-10-25 15:02:00.000000000 -0400
+@@ -321,14 +321,79 @@
+             $('#id_arguments').select2({ placeholder: 'Select arguments', allowClear: true });
+
++            let currentRollOptions = null;
++
++            async function calculateSHA256(file) {
++                const arrayBuffer = await file.arrayBuffer();
++                const hashBuffer = await crypto.subtle.digest('SHA-256', arrayBuffer);
++                const hashArray = Array.from(new Uint8Array(hashBuffer));
++                const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
++                return hashHex.toUpperCase();
++            }
++
++            $('#rom-validation-submit').on('click', async function() {
++                const fileInput = document.getElementById('rom-validation-file');
++                const errorDiv = document.getElementById('rom-validation-error');
++                const rememberCheckbox = document.getElementById('remember-rom-validation');
++
++                if (!fileInput.files || fileInput.files.length === 0) {
++                    errorDiv.innerText = "Please select a ROM file.";
++                    errorDiv.style.display = 'block';
++                    return;
++                }
++
++                const file = fileInput.files[0];
++                errorDiv.style.display = 'none';
++                $(this).prop('disabled', true).text('Validating...');
++
++                try {
++                    const hash = await calculateSHA256(file);
++                    const validHashes = [
++                        '0F51B4FCA41B7FD509E4B8F9D543151F68EFA5E97B08493E4B2A0C06F5D8D5E2', // Unheadered
++                        '60F6F506F928A6D3A6F1D0E43E5101E689C8F5B191B93F7159986326E1E909B1'  // Headered
++                    ];
++
++                    if (validHashes.includes(hash)) {
++                        if (rememberCheckbox.checked) {
++                            localStorage.setItem('romValidated', 'true');
++                        }
++                        closeModal('rom-validation-modal');
++                        if (currentRollOptions) {
++                            initiateTaskAndPoll(currentRollOptions);
++                        }
++                    } else {
++                        errorDiv.innerText = "Invalid ROM file. The sha256 value does not match the expected value.";
++                        errorDiv.style.display = 'block';
++                    }
++                } catch (error) {
++                    errorDiv.innerText = "Error reading or validating the file. Please try again.";
++                    errorDiv.style.display = 'block';
++                    console.error("ROM validation error:", error);
++                } finally {
++                    $(this).prop('disabled', false).text('Validate and Roll');
++                }
++            });
++
+             $(document).on('click', '.js-roll-seed-dispatcher', function() {
+                 const button = $(this);
+                 const randomLine = SILLY_THINGS.length > 0 ? SILLY_THINGS[Math.floor(Math.random() * SILLY_THINGS.length)] : "Rolling your seed...";
+
+-                initiateTaskAndPoll({
+-                    dispatcherUrl: button.data('url'),
+-                    statusUrlBase: button.data('status-url-base'),
+-                    modalTitle: 'Rolling Seed...',
+-                    modalMessage: randomLine.charAt(0).toUpperCase() + randomLine.slice(1),
+-                });
++                currentRollOptions = {
++                    dispatcherUrl: button.data('url'),
++                    statusUrlBase: button.data('status-url-base'),
++                    modalTitle: 'Rolling Seed...',
++                    modalMessage: randomLine.charAt(0).toUpperCase() + randomLine.slice(1),
++                };
++
++                const isValidated = localStorage.getItem('romValidated') === 'true';
++
++                if (isValidated) {
++                    initiateTaskAndPoll(currentRollOptions);
++                } else {
++                    // Reset the form
++                    $('#rom-validation-file').val('');
++                    $('#rom-validation-error').hide();
++                    openModal('rom-validation-modal');
++                }
+             });
+
+             $(document).on('click', '.js-feature-btn', function() {

--- a/templates/base.html
+++ b/templates/base.html
@@ -155,7 +155,7 @@
                 <p>
                     To download patched ROM files, please validate that you own a copy of Final Fantasy III.
                     <br><br>
-                    <em>"Obtain a Final Fantasy III Version 1.0 US ROM. Worlds Collide will automatically validate the uploaded ROM file and return an error if it does not match the expected sha256 value. Headered and unheadered ROMs are both acceptable."</em>
+                    SeedBot will automatically validate the uploaded ROM. Headered and unheadered ROMs are both acceptable.
                 </p>
                 <input type="file" id="rom-validation-file" accept=".smc,.sfc">
                 <div id="rom-validation-error" style="color: var(--pico-form-element-invalid-border-color); display: none; margin-top: 1rem;">

--- a/templates/base.html.orig
+++ b/templates/base.html.orig
@@ -13,7 +13,7 @@
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','{{ GOOGLE_TAG_MANAGER_ID }}');</script>
     {% endif %}
-    
+
     <link rel="icon" type="image/png" href="{% static 'images/seedbot_new.png' %}">
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"/>
@@ -199,7 +199,7 @@
                         if (data.status === 'SUCCESS') {
                             clearInterval(interval);
                             header.innerText = 'Seed Generated!';
-                            
+
                             // Handle both local files and external URLs
                             if (data.result.startsWith('http')) {
                                 content.innerHTML = `<p>Your seed is ready!</p><h4><a href="${data.result}" target="_blank">Open Seed Page</a></h4>`;
@@ -209,7 +209,7 @@
                                 window.location.href = data.result;
                             }
                             footer.style.display = 'block';
-                            
+
                         } else if (data.status === 'FAILURE') {
                             clearInterval(interval);
                             header.innerText = 'An Error Occurred';
@@ -320,80 +320,16 @@
         jQuery(document).ready(function($) {
             $('#id_arguments').select2({ placeholder: 'Select arguments', allowClear: true });
 
-            let currentRollOptions = null;
-
-            async function calculateSHA256(file) {
-                const arrayBuffer = await file.arrayBuffer();
-                const hashBuffer = await crypto.subtle.digest('SHA-256', arrayBuffer);
-                const hashArray = Array.from(new Uint8Array(hashBuffer));
-                const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
-                return hashHex.toUpperCase();
-            }
-
-            $('#rom-validation-submit').on('click', async function() {
-                const fileInput = document.getElementById('rom-validation-file');
-                const errorDiv = document.getElementById('rom-validation-error');
-                const rememberCheckbox = document.getElementById('remember-rom-validation');
-
-                if (!fileInput.files || fileInput.files.length === 0) {
-                    errorDiv.innerText = "Please select a ROM file.";
-                    errorDiv.style.display = 'block';
-                    return;
-                }
-
-                const file = fileInput.files[0];
-                errorDiv.style.display = 'none';
-                $(this).prop('disabled', true).text('Validating...');
-
-                try {
-                    const hash = await calculateSHA256(file);
-                    const validHashes = [
-                        '0F51B4FCA41B7FD509E4B8F9D543151F68EFA5E97B08493E4B2A0C06F5D8D5E2', // Unheadered
-                        '60F6F506F928A6D3A6F1D0E43E5101E689C8F5B191B93F7159986326E1E909B1'  // Headered
-                    ];
-
-                    if (validHashes.includes(hash)) {
-                        if (rememberCheckbox.checked) {
-                            localStorage.setItem('romValidated', 'true');
-                        }
-                        closeModal('rom-validation-modal');
-                        if (currentRollOptions) {
-                            initiateTaskAndPoll(currentRollOptions);
-                        }
-                    } else {
-                        errorDiv.innerText = "Invalid ROM file. The sha256 value does not match the expected value.";
-                        errorDiv.style.display = 'block';
-                    }
-                } catch (error) {
-                    errorDiv.innerText = "Error reading or validating the file. Please try again.";
-                    errorDiv.style.display = 'block';
-                    console.error("ROM validation error:", error);
-                } finally {
-                    $(this).prop('disabled', false).text('Validate and Roll');
-                }
-            });
-
             $(document).on('click', '.js-roll-seed-dispatcher', function() {
                 const button = $(this);
                 const randomLine = SILLY_THINGS.length > 0 ? SILLY_THINGS[Math.floor(Math.random() * SILLY_THINGS.length)] : "Rolling your seed...";
 
-                currentRollOptions = {
+                initiateTaskAndPoll({
                     dispatcherUrl: button.data('url'),
                     statusUrlBase: button.data('status-url-base'),
                     modalTitle: 'Rolling Seed...',
                     modalMessage: randomLine.charAt(0).toUpperCase() + randomLine.slice(1),
-                };
-
-                const isValidated = localStorage.getItem('romValidated') === 'true';
-
-                if (isValidated) {
-                    initiateTaskAndPoll(currentRollOptions);
-                } else {
-                    // Reset the form
-                    $('#rom-validation-file').val('');
-                    $('#rom-validation-error').hide();
-                    openModal('rom-validation-modal');
-                }
+                });
             });
 
             $(document).on('click', '.js-feature-btn', function() {
@@ -441,7 +377,7 @@
                 const card = button.closest('article');
                 const cardPk = card.data('pk');
                 const csrfToken = $('[name=csrfmiddlewaretoken]').val();
-                
+
                 fetch(favoriteUrl, { method: 'POST', headers: { 'X-CSRFToken': csrfToken }})
                 .then(response => response.json())
                 .then(data => {
@@ -451,7 +387,7 @@
 
                         const isFeatured = card.closest('#featured-grid').length > 0 || $('#featured-grid').find(`article[data-pk='${cardPk}']`).length > 0;
                         const favoriteGrid = $('#favorite-grid');
-                        
+
                         if (favoriteGrid.length) {
                             if (data.favorited) {
                                 // Add a copy to the favorites grid
@@ -479,7 +415,7 @@
         });
     </script>
     {% block scripts %}
-    
+
     <script>
     document.addEventListener('DOMContentLoaded', () => {
         const yamlModal = document.getElementById('yaml-modal');
@@ -488,7 +424,7 @@
 
         const yamlModalForm = document.getElementById('yaml-modal-form');
         const presetNameSpan = document.getElementById('yaml-modal-preset-name');
-        
+
         // Add event listeners to all "Make .yaml" buttons
         document.querySelectorAll('.js-show-yaml-modal').forEach(button => {
             button.addEventListener('click', event => {
@@ -498,7 +434,7 @@
                 // Populate modal with preset-specific info
                 presetNameSpan.textContent = presetName;
                 yamlModalForm.action = formUrl;
-                
+
                 // Reset form to its default checked values
                 yamlModalForm.reset();
 


### PR DESCRIPTION
Added a client-side ROM validation step to the seed rolling process to ensure users own a copy of Final Fantasy III Version 1.0 US.

Changes:
1.  **Modal UI:** Added a new `<dialog>` in `templates/base.html` containing a file input, a checkbox to remember validation, error message placeholders, and explanatory text.
2.  **Validation Logic:** Implemented a JavaScript handler using the Web Crypto API (`crypto.subtle.digest`) to calculate the SHA-256 hash of the uploaded `.smc` or `.sfc` file on the client side.
3.  **Hash Verification:** Compares the computed hash against the known valid hashes for unheadered (`0F51B4FCA41B7FD509E4B8F9D543151F68EFA5E97B08493E4B2A0C06F5D8D5E2`) and headered (`60F6F506F928A6D3A6F1D0E43E5101E689C8F5B191B93F7159986326E1E909B1`) ROMs.
4.  **Integration:** Modified the click listener for `.js-roll-seed-dispatcher` buttons. If validation is required (and not remembered in `localStorage`), it intercepts the action, opens the modal, and temporarily stores the roll options. Upon successful validation, it stores the status in `localStorage` (if requested) and triggers the original seed roll API call automatically.

This is a robust, client-side only approach that prevents unnecessary file uploads to the server while ensuring compliance.

---
*PR created automatically by Jules for task [15472932140716891932](https://jules.google.com/task/15472932140716891932) started by @wrjones104*