### PR TITLE
Add User-Agent headers to API requests to differentiate clients

### DIFF
--- a/bot/functions.py
+++ b/bot/functions.py
@@ -37,7 +37,7 @@ async def generate_v1_seed(flags, seed_desc, dev):
         payload_data["description"] = seed_desc
     
     payload = json.dumps(payload_data)
-    headers = {"Content-Type": "application/json"}
+    headers = {"Content-Type": "application/json", "User-Agent": "SeedBot-Discord"}
 
     async with aiohttp.ClientSession() as session:
         async with session.post(url, headers=headers, data=payload) as r:
@@ -49,7 +49,8 @@ async def generate_v1_seed(flags, seed_desc, dev):
 
 async def get_vers():
     url = "https://api.ff6worldscollide.com/api/wc"
-    response = requests.request("GET", url)
+    headers = {"User-Agent": "SeedBot-Discord"}
+    response = requests.request("GET", url, headers=headers)
     data = response.json()
     return data
 

--- a/webapp/tasks.py
+++ b/webapp/tasks.py
@@ -384,7 +384,7 @@ def create_api_seed_task(self, preset_pk, discord_id, user_name):
         
         api_url = "https://api.ff6worldscollide.com/api/seed"
         payload = {"key": settings.WC_API_KEY, "flags": final_flags}
-        headers = {"Content-Type": "application/json"}
+        headers = {"Content-Type": "application/json", "User-Agent": "SeedBot-WebApp"}
         
         response = requests.post(api_url, data=json.dumps(payload), headers=headers, timeout=30)
         response.raise_for_status()


### PR DESCRIPTION
This change updates the HTTP headers sent to the FF6WC API to clearly indicate whether the request is coming from the Discord Bot or the Web Application.

Changes:
*   Updated `generate_v1_seed` and `get_vers` in `bot/functions.py` to include `"User-Agent": "SeedBot-Discord"`.
*   Updated `create_api_seed_task` in `webapp/tasks.py` to include `"User-Agent": "SeedBot-WebApp"`.

---
*PR created automatically by Jules for task [14063046866798160210](https://jules.google.com/task/14063046866798160210) started by @wrjones104*