### PR TITLE
Address PR comments for User-Agent headers and async API call

### DIFF
--- a/bot/functions.py
+++ b/bot/functions.py
@@ -24,6 +24,8 @@ from bot.utils.zip_seed import create_seed_zip
 
 logger = logging.getLogger(__name__)
 
+USER_AGENT_DISCORD = "SeedBot-Discord"
+
 async def generate_v1_seed(flags, seed_desc, dev):
     if dev == "dev":
         url = "https://devapi.ff6worldscollide.com/api/seed"
@@ -37,7 +39,7 @@ async def generate_v1_seed(flags, seed_desc, dev):
         payload_data["description"] = seed_desc
     
     payload = json.dumps(payload_data)
-    headers = {"Content-Type": "application/json"}
+    headers = {"Content-Type": "application/json", "User-Agent": USER_AGENT_DISCORD}
 
     async with aiohttp.ClientSession() as session:
         async with session.post(url, headers=headers, data=payload) as r:
@@ -49,9 +51,11 @@ async def generate_v1_seed(flags, seed_desc, dev):
 
 async def get_vers():
     url = "https://api.ff6worldscollide.com/api/wc"
-    response = requests.request("GET", url)
-    data = response.json()
-    return data
+    headers = {"User-Agent": USER_AGENT_DISCORD}
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, headers=headers) as response:
+            response.raise_for_status()
+            return await response.json()
 
 
 async def db_con():

--- a/webapp/tasks.py
+++ b/webapp/tasks.py
@@ -25,6 +25,7 @@ from bot.utils.tunes_processor import apply_tunes
 from bot.utils.metric_writer import write_gsheets
 from bot.utils.zip_seed import create_seed_zip
 
+USER_AGENT_WEBAPP = "SeedBot-WebApp"
 
 def _robust_delete(file_path, retries=3, delay=0.1):
     """Attempts to delete a file, retrying on PermissionError."""
@@ -384,7 +385,7 @@ def create_api_seed_task(self, preset_pk, discord_id, user_name):
         
         api_url = "https://api.ff6worldscollide.com/api/seed"
         payload = {"key": settings.WC_API_KEY, "flags": final_flags}
-        headers = {"Content-Type": "application/json"}
+        headers = {"Content-Type": "application/json", "User-Agent": USER_AGENT_WEBAPP}
         
         response = requests.post(api_url, data=json.dumps(payload), headers=headers, timeout=30)
         response.raise_for_status()


### PR DESCRIPTION
Address PR comments for User-Agent headers

*   Defined `USER_AGENT_DISCORD = "SeedBot-Discord"` in `bot/functions.py` and used it in API calls.
*   Updated `get_vers` in `bot/functions.py` to use `aiohttp.ClientSession()` to prevent blocking the async event loop.
*   Defined `USER_AGENT_WEBAPP = "SeedBot-WebApp"` in `webapp/tasks.py` and used it in the API call for consistency.

---
*PR created automatically by Jules for task [14063046866798160210](https://jules.google.com/task/14063046866798160210) started by @wrjones104*