### PR TITLE
🧹 Remove commented-out code in sitemaps.py

### DIFF
--- a/webapp/sitemaps.py
+++ b/webapp/sitemaps.py
@@ -12,16 +12,3 @@ class StaticViewSitemap(Sitemap):
     
     def location(self, item):
         return reverse(item)
-
-# Example for dynamic pages
-# class PresetSitemap(Sitemap):
-#     changefreq = "weekly"
-#     priority = 0.9
-#
-#     def items(self):
-#         # Return a queryset of public presets
-#         return Preset.objects.filter(public=True)
-#
-#     def lastmod(self, obj):
-#         # Return the last modified date for each preset
-#         return obj.updated_at


### PR DESCRIPTION
This PR removes commented-out example code in `webapp/sitemaps.py` that was no longer needed.

🎯 **What:** Removed the commented-out `PresetSitemap` class and accompanying comments.
💡 **Why:** To improve maintainability and readability by removing dead code and reducing clutter.
✅ **Verification:** Verified the file contents after modification and ran `python3 -m py_compile webapp/sitemaps.py` to ensure syntax remains correct.
✨ **Result:** A cleaner `webapp/sitemaps.py` containing only the active `StaticViewSitemap` class.

---
*PR created automatically by Jules for task [13290274220514414766](https://jules.google.com/task/13290274220514414766) started by @wrjones104*