### PR TITLE
🧹 Remove unused imports in webapp/forms.py

### DIFF
--- a/webapp/forms.py
+++ b/webapp/forms.py
@@ -1,15 +1,6 @@
-import requests
-import json
-import subprocess
-import uuid
-import sys
-from pathlib import Path
-
 from django import forms
-from django.conf import settings
 from .models import Preset
 from profanity import profanity
-from bot.utils import flag_processor
 
 ARGUMENT_CHOICES = [
     ('paint', 'Paint'), ('kupo', 'Kupo'), ('loot', 'Loot'), ('fancygau', 'Fancy Gau'),


### PR DESCRIPTION
This PR improves code health by removing unused imports in `webapp/forms.py`. Specifically, it removes `requests`, `json`, `subprocess`, `uuid`, `sys`, `pathlib.Path`, `django.conf.settings`, and `bot.utils.flag_processor`.

Verification:
- Performed `grep` searches for each imported name to ensure they are not used in the file.
- Ran `python3 -m py_compile webapp/forms.py` to ensure no syntax or basic name errors were introduced.
- Attempted to run the full test suite, although Django was not available in the environment.
- Created the required `logs/` directory for the test suite.

---
*PR created automatically by Jules for task [1736123293909001046](https://jules.google.com/task/1736123293909001046) started by @wrjones104*