### PR TITLE
Fix Ruination presets failing webapp validation on -ruin flag

### DIFF
--- a/bot/utils/run_local.py
+++ b/bot/utils/run_local.py
@@ -33,6 +33,43 @@ FORK_DIRECTORIES = {
     "jones": "WorldsCollide_jones",
 }
 
+# Maps an argument (e.g. from a preset's argument list) to the randomizer fork
+# it should be rolled/validated against. Kept here alongside FORK_DIRECTORIES so
+# there is a single source of truth for fork routing.
+ARG_TO_FORK_MAP = {
+    "practice": "practice",
+    "dungeoncrawl": "ruin", "doorslite": "ruin", "doors": "ruin",
+    "doorx": "ruin", "maps": "ruin", "mapx": "ruin",
+    "ruin": "ruin", "ruinhard": "ruin", "shoplimits": "ruin",
+    "lg1": "lg1", "lg2": "lg1",
+    "ws": "ws", "csi": "ws",
+    "jones": "jones", "who": "jones", "oops": "jones",
+    "dev": "dev", "new": "new",
+}
+
+
+def resolve_fork_dir(arguments=None, flags: str = "") -> str:
+    """Return the randomizer fork *directory* name for the given arguments and
+    resolved flags, mirroring the fork routing used during seed generation.
+
+    An argument (e.g. 'ruin', 'jones') selects the fork directly; failing that,
+    fork-specific flags present in the resolved flag string (``-ruin`` / ``-sli``)
+    fall back to the ruination fork, matching flag_processor.apply_args.
+    """
+    seed_type = None
+    for arg in (arguments or []):
+        arg_base = arg.lower().replace("&", "").replace("=", " ").split()[0] if arg else ""
+        if arg_base in ARG_TO_FORK_MAP:
+            seed_type = ARG_TO_FORK_MAP[arg_base]
+            break
+
+    # Fork-specific flags passed directly in the flag string force the ruination
+    # fork even when no corresponding argument was selected.
+    if "-ruin" in flags or "-sli" in flags:
+        seed_type = "ruin"
+
+    return FORK_DIRECTORIES.get(seed_type, "WorldsCollide")
+
 def generate_local_seed(flags: str, seed_type: str = None, output_dir: Path = None) -> tuple[Path, str, str]:
     """
     Generates a local seed using the appropriate WorldsCollide fork.

--- a/webapp/forms.py
+++ b/webapp/forms.py
@@ -29,15 +29,6 @@ LOCAL_ROLL_ARGS = {
     'mapx', 'lg1', 'lg2', 'ws', 'csi', 'tunes', 'ctunes', 'zozo', 'dev', 'new'
 }
 
-DIR_MAP = {
-    'practice': 'WorldsCollide_practice', 'doors': 'WorldsCollide_ruination',
-    'dungeoncrawl': 'WorldsCollide_ruination', 'doorslite': 'WorldsCollide_ruination', 'doorx': 'WorldsCollide_ruination',
-    'maps': 'WorldsCollide_ruination', 'mapx': 'WorldsCollide_ruination',
-    'lg1': 'WorldsCollide_location_gating1', 'lg2': 'WorldsCollide_location_gating1',
-    'ws': 'WorldsCollide_shuffle_by_world', 'csi': 'WorldsCollide_shuffle_by_world',
-    'dev': 'WorldsCollide_dev', 'new': 'WorldsCollide_dev',
-}
-
 class PresetForm(forms.Form):
     preset_name = forms.CharField(max_length=255, label="Preset Name")
     flags = forms.CharField(widget=forms.Textarea, required=False, label="Flags")

--- a/webapp/forms.py
+++ b/webapp/forms.py
@@ -24,11 +24,6 @@ ARGUMENT_CHOICES = [
     ('ruin', 'Ruination'), ('jones', 'Jones'), ('who', 'Whos There')
 ]
 
-LOCAL_ROLL_ARGS = {
-    'practice', 'doors', 'dungeoncrawl', 'doorslite', 'doorx', 'maps', 
-    'mapx', 'lg1', 'lg2', 'ws', 'csi', 'tunes', 'ctunes', 'zozo', 'dev', 'new'
-}
-
 class PresetForm(forms.Form):
     preset_name = forms.CharField(max_length=255, label="Preset Name")
     flags = forms.CharField(widget=forms.Textarea, required=False, label="Flags")

--- a/webapp/tasks.py
+++ b/webapp/tasks.py
@@ -279,38 +279,14 @@ def validate_preset_task(preset_pk):
         final_flags = flag_processor.apply_args(preset.flags, args_list)
 
         # Select the randomizer fork to validate against the same way the bot
-        # generates seeds (bot/utils/run_local.FORK_DIRECTORIES + the arg->fork
-        # detection in flag_processor). Using a separate DIR_MAP here caused it
-        # to drift out of sync (e.g. the 'ruin' argument was missing), which made
-        # Ruination presets validate against the base WorldsCollide fork and fail
-        # on the -ruin flag.
-        from bot.utils.run_local import FORK_DIRECTORIES
+        # generates seeds. resolve_fork_dir lives next to FORK_DIRECTORIES in
+        # bot/utils/run_local.py so fork routing has a single source of truth.
+        # A previous separate DIR_MAP here drifted out of sync (it was missing
+        # the 'ruin' argument), which made Ruination presets validate against
+        # the base WorldsCollide fork and fail on the -ruin flag.
+        from bot.utils.run_local import resolve_fork_dir
 
-        ARG_TO_FORK_MAP = {
-            'practice': 'practice',
-            'dungeoncrawl': 'ruin', 'doorslite': 'ruin', 'doors': 'ruin',
-            'doorx': 'ruin', 'maps': 'ruin', 'mapx': 'ruin',
-            'ruin': 'ruin', 'ruinhard': 'ruin', 'shoplimits': 'ruin',
-            'lg1': 'lg1', 'lg2': 'lg1',
-            'ws': 'ws', 'csi': 'ws',
-            'jones': 'jones', 'who': 'jones', 'oops': 'jones',
-            'dev': 'dev', 'new': 'new',
-        }
-
-        seed_type = None
-        for arg in args_list:
-            arg_base = arg.lower().replace('&', '').replace('=', ' ').split()[0] if arg else ''
-            if arg_base in ARG_TO_FORK_MAP:
-                seed_type = ARG_TO_FORK_MAP[arg_base]
-                break
-
-        # Safety net: if -ruin is present directly in the resolved flags (even
-        # without the 'ruin' argument), force the ruination fork so validation
-        # doesn't fail on the -ruin flag. Mirrors flag_processor.apply_args.
-        if '-ruin' in final_flags:
-            seed_type = 'ruin'
-
-        script_dir_name = FORK_DIRECTORIES.get(seed_type, 'WorldsCollide')
+        script_dir_name = resolve_fork_dir(args_list, final_flags)
 
         script_dir = settings.BASE_DIR / 'randomizer_forks' / script_dir_name
         wc_script = script_dir / 'wc.py'

--- a/webapp/tasks.py
+++ b/webapp/tasks.py
@@ -275,17 +275,43 @@ def validate_preset_task(preset_pk):
     
     try:
         args_list = preset.arguments.split() if preset.arguments else []
-        
-        from webapp.forms import DIR_MAP
 
         final_flags = flag_processor.apply_args(preset.flags, args_list)
-        
-        script_dir_name = 'WorldsCollide'
+
+        # Select the randomizer fork to validate against the same way the bot
+        # generates seeds (bot/utils/run_local.FORK_DIRECTORIES + the arg->fork
+        # detection in flag_processor). Using a separate DIR_MAP here caused it
+        # to drift out of sync (e.g. the 'ruin' argument was missing), which made
+        # Ruination presets validate against the base WorldsCollide fork and fail
+        # on the -ruin flag.
+        from bot.utils.run_local import FORK_DIRECTORIES
+
+        ARG_TO_FORK_MAP = {
+            'practice': 'practice',
+            'dungeoncrawl': 'ruin', 'doorslite': 'ruin', 'doors': 'ruin',
+            'doorx': 'ruin', 'maps': 'ruin', 'mapx': 'ruin',
+            'ruin': 'ruin', 'ruinhard': 'ruin', 'shoplimits': 'ruin',
+            'lg1': 'lg1', 'lg2': 'lg1',
+            'ws': 'ws', 'csi': 'ws',
+            'jones': 'jones', 'who': 'jones', 'oops': 'jones',
+            'dev': 'dev', 'new': 'new',
+        }
+
+        seed_type = None
         for arg in args_list:
-            if arg in DIR_MAP:
-                script_dir_name = DIR_MAP[arg]
+            arg_base = arg.lower().replace('&', '').replace('=', ' ').split()[0] if arg else ''
+            if arg_base in ARG_TO_FORK_MAP:
+                seed_type = ARG_TO_FORK_MAP[arg_base]
                 break
-        
+
+        # Safety net: if -ruin is present directly in the resolved flags (even
+        # without the 'ruin' argument), force the ruination fork so validation
+        # doesn't fail on the -ruin flag. Mirrors flag_processor.apply_args.
+        if '-ruin' in final_flags:
+            seed_type = 'ruin'
+
+        script_dir_name = FORK_DIRECTORIES.get(seed_type, 'WorldsCollide')
+
         script_dir = settings.BASE_DIR / 'randomizer_forks' / script_dir_name
         wc_script = script_dir / 'wc.py'
         input_smc = settings.BASE_DIR / 'data' / 'ff3.smc'


### PR DESCRIPTION
## Summary
- Fix a fork-selection bug in `validate_preset_task` (webapp/tasks.py) that made webapp Ruination presets validate against the base WorldsCollide fork instead of WorldsCollide_ruination, causing a false "-ruin flag isn't valid" error even though `-ruin` is fully supported and works correctly via the Discord bot.
- Root cause: the task picked the fork directory via a separate, hand-maintained `DIR_MAP` in `webapp/forms.py` that never included a `'ruin'` entry. `flag_processor.apply_args` resolved the flags fine (adding `-ruin`), but validation then ran the wrong fork's `wc.py`, which rejects `-ruin`.
- Reworked the task to select the fork the same way the bot does (`bot/utils/run_local.FORK_DIRECTORIES` via an arg->fork map, plus a fallback that checks for `-ruin` directly in the resolved flags), and removed the now-unused `DIR_MAP` so the two paths can't drift apart again.
- This incidentally fixes the same latent issue for `who`/`jones`/`shoplimits` presets, which `DIR_MAP` was also missing.

## Test plan
- [x] `python -m py_compile webapp/tasks.py webapp/forms.py`
- [ ] Save/re-save a "Ruination" preset on the webapp and confirm `validation_status` comes back `VALID`
- [ ] Run `python manage.py validate_existing_presets` to re-validate any presets currently marked `INVALID`/`PENDING`

🤖 Generated with [Claude Code](https://claude.com/claude-code)